### PR TITLE
Add NSFW blur toggle

### DIFF
--- a/app/src/main/java/me/mudkip/moememos/MainActivity.kt
+++ b/app/src/main/java/me/mudkip/moememos/MainActivity.kt
@@ -10,14 +10,17 @@ import androidx.core.view.WindowCompat
 import dagger.hilt.android.AndroidEntryPoint
 import me.mudkip.moememos.ui.page.common.Navigation
 import me.mudkip.moememos.viewmodel.LocalMemos
+import me.mudkip.moememos.viewmodel.LocalSettings
 import me.mudkip.moememos.viewmodel.LocalUserState
 import me.mudkip.moememos.viewmodel.MemosViewModel
+import me.mudkip.moememos.viewmodel.SettingsViewModel
 import me.mudkip.moememos.viewmodel.UserStateViewModel
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     private val userStateViewModel: UserStateViewModel by viewModels()
     private val memosViewModel: MemosViewModel by viewModels()
+    private val settingsViewModel: SettingsViewModel by viewModels()
 
     companion object {
         const val ACTION_NEW_MEMO = "me.mudkip.moememos.action.NEW_MEMO"
@@ -31,7 +34,8 @@ class MainActivity : ComponentActivity() {
         setContent {
             CompositionLocalProvider(
                 LocalUserState provides userStateViewModel,
-                LocalMemos provides memosViewModel
+                LocalMemos provides memosViewModel,
+                LocalSettings provides settingsViewModel
             ) {
                 Navigation()
             }

--- a/app/src/main/java/me/mudkip/moememos/data/model/Account.kt
+++ b/app/src/main/java/me/mudkip/moememos/data/model/Account.kt
@@ -7,10 +7,25 @@ sealed class Account {
         Local -> "local"
     }
 
-    fun toUserData(): UserData = when (this) {
-        is MemosV0 -> UserData.newBuilder().setAccountKey(accountKey()).setMemosV0(this.info).build()
-        is MemosV1 -> UserData.newBuilder().setAccountKey(accountKey()).setMemosV1(this.info).build()
-        Local -> UserData.newBuilder().setAccountKey(accountKey()).setLocal(LocalAccount.getDefaultInstance()).build()
+    fun toUserData(): UserData {
+        val settings = UserSettings.newBuilder().setBlurNsfw(true).build()
+        return when (this) {
+            is MemosV0 -> UserData.newBuilder()
+                .setAccountKey(accountKey())
+                .setMemosV0(this.info)
+                .setSettings(settings)
+                .build()
+            is MemosV1 -> UserData.newBuilder()
+                .setAccountKey(accountKey())
+                .setMemosV1(this.info)
+                .setSettings(settings)
+                .build()
+            Local -> UserData.newBuilder()
+                .setAccountKey(accountKey())
+                .setLocal(LocalAccount.getDefaultInstance())
+                .setSettings(settings)
+                .build()
+        }
     }
 
     companion object {

--- a/app/src/main/java/me/mudkip/moememos/ui/component/MemosCard.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/component/MemosCard.kt
@@ -39,10 +39,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.draw.blur
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.skydoves.sandwich.suspendOnSuccess
@@ -67,6 +69,8 @@ fun MemosCard(
 ) {
     val memosViewModel = LocalMemos.current
     val scope = rememberCoroutineScope()
+    val isNsfw = memo.content.contains("#nsfw", ignoreCase = true)
+    var blurred by rememberSaveable(isNsfw) { mutableStateOf(isNsfw) }
 
     Card(
         modifier = Modifier
@@ -80,15 +84,18 @@ fun MemosCard(
     ) {
         Box(
             modifier = Modifier
-                .pointerInput(Unit) {
+                .pointerInput(isNsfw) {
                     detectTapGestures(
                         onLongPress = {
                             onEdit(memo)
+                        },
+                        onTap = {
+                            if (isNsfw) blurred = !blurred
                         }
                     )
                 }
         ) {
-            Column {
+            Column(modifier = Modifier.blur(if (blurred) 16.dp else 0.dp)) {
                 Row(
                     modifier = Modifier
                         .padding(start = 15.dp)

--- a/app/src/main/java/me/mudkip/moememos/ui/component/MemosCard.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/component/MemosCard.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -58,6 +59,7 @@ import me.mudkip.moememos.ext.titleResource
 import me.mudkip.moememos.ui.page.common.LocalRootNavController
 import me.mudkip.moememos.ui.page.common.RouteName
 import me.mudkip.moememos.viewmodel.LocalMemos
+import me.mudkip.moememos.viewmodel.LocalSettings
 import me.mudkip.moememos.viewmodel.LocalUserState
 
 @Composable
@@ -70,7 +72,8 @@ fun MemosCard(
     val memosViewModel = LocalMemos.current
     val scope = rememberCoroutineScope()
     val isNsfw = memo.content.contains("#nsfw", ignoreCase = true)
-    var blurred by rememberSaveable(isNsfw) { mutableStateOf(isNsfw) }
+    val defaultBlur by LocalSettings.current.blurNsfw.collectAsState()
+    var blurred by rememberSaveable(isNsfw, defaultBlur) { mutableStateOf(isNsfw && defaultBlur) }
 
     Card(
         modifier = Modifier

--- a/app/src/main/java/me/mudkip/moememos/ui/component/MemosCard.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/component/MemosCard.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.pointerInteropFilter
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.res.stringResource
@@ -63,6 +64,7 @@ import me.mudkip.moememos.viewmodel.LocalMemos
 import me.mudkip.moememos.viewmodel.LocalSettings
 import me.mudkip.moememos.viewmodel.LocalUserState
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun MemosCard(
     memo: Memo,

--- a/app/src/main/java/me/mudkip/moememos/ui/component/MemosCard.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/component/MemosCard.kt
@@ -44,9 +44,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.input.pointer.awaitPointerEventScope
-import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.consume
+import androidx.compose.ui.input.pointer.awaitPointerEvent
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.draw.blur
 import androidx.compose.foundation.layout.matchParentSize
@@ -159,11 +158,9 @@ fun MemosCard(
                     modifier = Modifier
                         .matchParentSize()
                         .pointerInput(Unit) {
-                            awaitPointerEventScope {
-                                while (true) {
-                                    val event = awaitPointerEvent()
-                                    event.changes.forEach { it.consume() }
-                                }
+                            while (true) {
+                                val event = awaitPointerEvent()
+                                event.changes.forEach { it.consume() }
                             }
                         }
                 )

--- a/app/src/main/java/me/mudkip/moememos/ui/component/MemosCard.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/component/MemosCard.kt
@@ -44,11 +44,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.input.pointer.consume
-import androidx.compose.ui.input.pointer.awaitPointerEvent
+import androidx.compose.ui.input.pointer.pointerInteropFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.draw.blur
-import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.skydoves.sandwich.suspendOnSuccess
@@ -156,13 +154,8 @@ fun MemosCard(
             if (blurred) {
                 Box(
                     modifier = Modifier
-                        .matchParentSize()
-                        .pointerInput(Unit) {
-                            while (true) {
-                                val event = awaitPointerEvent()
-                                event.changes.forEach { it.consume() }
-                            }
-                        }
+                        .fillMaxSize()
+                        .pointerInteropFilter { true }
                 )
             }
         }

--- a/app/src/main/java/me/mudkip/moememos/ui/component/MemosCard.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/component/MemosCard.kt
@@ -44,8 +44,12 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.awaitPointerEventScope
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.consume
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.draw.blur
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.skydoves.sandwich.suspendOnSuccess
@@ -98,7 +102,9 @@ fun MemosCard(
                     )
                 }
         ) {
-            Column(modifier = Modifier.blur(if (blurred) 16.dp else 0.dp)) {
+            Column(
+                modifier = Modifier.blur(if (blurred) 16.dp else 0.dp)
+            ) {
                 Row(
                     modifier = Modifier
                         .padding(start = 15.dp)
@@ -147,6 +153,20 @@ fun MemosCard(
                             )
                         }
                     })
+            }
+            if (blurred) {
+                Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .pointerInput(Unit) {
+                            awaitPointerEventScope {
+                                while (true) {
+                                    val event = awaitPointerEvent()
+                                    event.changes.forEach { it.consume() }
+                                }
+                            }
+                        }
+                )
             }
         }
     }

--- a/app/src/main/java/me/mudkip/moememos/ui/page/settings/SettingsPage.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/page/settings/SettingsPage.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.PersonAdd
 import androidx.compose.material.icons.outlined.Source
 import androidx.compose.material.icons.outlined.Web
+import androidx.compose.material.icons.outlined.BlurOn
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -22,6 +23,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.material3.Switch
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -34,6 +36,7 @@ import me.mudkip.moememos.ext.popBackStackIfLifecycleIsResumed
 import me.mudkip.moememos.ext.string
 import me.mudkip.moememos.ui.component.MemosIcon
 import me.mudkip.moememos.ui.page.common.RouteName
+import me.mudkip.moememos.viewmodel.LocalSettings
 import me.mudkip.moememos.viewmodel.LocalUserState
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -112,6 +115,18 @@ fun SettingsPage(
             item {
                 SettingItem(icon = Icons.Outlined.PersonAdd, text = R.string.add_account.string) {
                     navController.navigate(RouteName.LOGIN)
+                }
+            }
+
+            item {
+                val settingsViewModel = LocalSettings.current
+                val blurNsfw by settingsViewModel.blurNsfw.collectAsState()
+                SettingItem(icon = Icons.Outlined.BlurOn, text = R.string.blur_nsfw_memos.string,
+                    trailingIcon = {
+                        Switch(checked = blurNsfw, onCheckedChange = null)
+                    }
+                ) {
+                    settingsViewModel.setBlurNsfw(!blurNsfw)
                 }
             }
 

--- a/app/src/main/java/me/mudkip/moememos/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/me/mudkip/moememos/viewmodel/SettingsViewModel.kt
@@ -1,0 +1,41 @@
+package me.mudkip.moememos.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import me.mudkip.moememos.ext.settingsDataStore
+import me.mudkip.moememos.data.model.UserSettings
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    @ApplicationContext private val context: Context
+) : ViewModel() {
+    val blurNsfw = context.settingsDataStore.data.map { settings ->
+        val user = settings.usersList.firstOrNull { it.accountKey == settings.currentUser }
+        val userSettings = user?.settings ?: UserSettings.getDefaultInstance()
+        if (userSettings.hasBlurNsfw()) userSettings.blurNsfw else true
+    }.stateIn(viewModelScope, SharingStarted.Lazily, true)
+
+    fun setBlurNsfw(enabled: Boolean) = viewModelScope.launch {
+        context.settingsDataStore.updateData { settings ->
+            val currentUser = settings.usersList.firstOrNull { it.accountKey == settings.currentUser }
+                ?: return@updateData settings
+            val index = settings.usersList.indexOf(currentUser)
+            val updatedUser = currentUser.toBuilder().apply {
+                this.settings = this.settings.toBuilder().setBlurNsfw(enabled).build()
+            }.build()
+            settings.toBuilder().setUsers(index, updatedUser).build()
+        }
+    }
+}
+
+val LocalSettings = androidx.compose.runtime.compositionLocalOf<SettingsViewModel> {
+    error("Settings view model not found")
+}

--- a/app/src/main/proto/data.proto
+++ b/app/src/main/proto/data.proto
@@ -15,6 +15,7 @@ message LocalAccount {}
 
 message UserSettings {
   string draft = 1;
+  optional bool blur_nsfw = 2;
 }
 
 message UserData {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -64,4 +64,5 @@
     <string name="accounts">Konten</string>
     <string name="account_detail">Kontodetail</string>
     <string name="switch_account">Konto wechseln</string>
+    <string name="blur_nsfw_memos">Blur #nsfw memos</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -66,4 +66,5 @@
     <string name="delete_this_tag">Supprimer cette étiquette ?</string>
     <string name="expand">Agrandir</string>
     <string name="collapse">Rétracter</string>
+    <string name="blur_nsfw_memos">Blur #nsfw memos</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -66,4 +66,5 @@
     <string name="delete_this_tag">Elimina questo tag?</string>
     <string name="expand">Espandi</string>
     <string name="collapse">Restringere</string>
+    <string name="blur_nsfw_memos">Blur #nsfw memos</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -66,4 +66,5 @@
     <string name="delete_this_tag">Удалить этот тег?</string>
     <string name="expand">Развернуть</string>
     <string name="collapse">Скрыть</string>
+    <string name="blur_nsfw_memos">Blur #nsfw memos</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -66,4 +66,5 @@
     <string name="delete_this_tag">Bu etiketi silmek istiyor musunuz?</string>
     <string name="expand">Genişlet</string>
     <string name="collapse">Daralt</string>
+    <string name="blur_nsfw_memos">Blur #nsfw memos</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -57,4 +57,5 @@
     <string name="memo_visibility_protected">本地用户可见</string>
     <string name="memo_visibility_private">仅自己可见</string>
     <string name="explore">探索</string>
+    <string name="blur_nsfw_memos">Blur #nsfw memos</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -58,4 +58,5 @@
     <string name="memo_visibility_protected">本地使用者可見</string>
     <string name="memo_visibility_private">僅自己可見</string>
     <string name="explore">探索</string>
+    <string name="blur_nsfw_memos">Blur #nsfw memos</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,7 @@
     <string name="accounts">Accounts</string>
     <string name="account_detail">Account Detail</string>
     <string name="switch_account">Switch Account</string>
+    <string name="blur_nsfw_memos">Blur #nsfw memos</string>
     
     <!-- Widget strings -->
     <string name="loading">Loading…</string>


### PR DESCRIPTION
## Summary
- blur memo cards when memo text contains `#nsfw`
- allow tapping the card to toggle blur

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685bd74df73c83309e666f7332b1fdb2