### PR TITLE
Fix blurred memo interaction

### DIFF
--- a/app/src/main/java/me/mudkip/moememos/ui/component/MemosCard.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/component/MemosCard.kt
@@ -157,7 +157,13 @@ fun MemosCard(
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .pointerInteropFilter { true }
+                        .pointerInput(Unit) {
+                            awaitPointerEventScope {
+                                while (true) {
+                                    awaitPointerEvent()
+                                }
+                            }
+                        }
                 )
             }
         }

--- a/app/src/main/java/me/mudkip/moememos/ui/component/MemosCard.kt
+++ b/app/src/main/java/me/mudkip/moememos/ui/component/MemosCard.kt
@@ -160,7 +160,8 @@ fun MemosCard(
                         .pointerInput(Unit) {
                             awaitPointerEventScope {
                                 while (true) {
-                                    awaitPointerEvent()
+                                    val event = awaitPointerEvent()
+                                    event.changes.forEach { it.consume() }
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- intercept pointer events when memo is blurred to disable interaction

## Testing
- `./gradlew test --dry-run` *(fails: Unable to download gradle)*

------
https://chatgpt.com/codex/tasks/task_e_685bed5365548330a720fd316c912f14